### PR TITLE
feat: add get current user API (issue #7)

### DIFF
--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { registerUser, loginUser } from '../services/users-service';
+import { registerUser, loginUser, getCurrentUser } from '../services/users-service';
 
 export const usersRoute = new Elysia()
   .post('/api/users', async ({ body }) => {
@@ -38,4 +38,23 @@ export const usersRoute = new Elysia()
       email: t.String({ format: 'email' }),
       password: t.String({ minLength: 6 })
     })
+  })
+  .get('/api/users/me', async ({ headers }) => {
+    const authHeader = headers.authorization;
+    
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return { error: 'Unauthorized' };
+    }
+    
+    const token = authHeader.substring(7);
+    
+    try {
+      const result = await getCurrentUser(token);
+      return result;
+    } catch (error: any) {
+      if (error.message === 'Unauthorized') {
+        return { error: 'Unauthorized' };
+      }
+      return { error: 'Internal server error' };
+    }
   });

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -43,3 +43,26 @@ export async function loginUser(email: string, password: string) {
   
   return { data: token };
 }
+
+export async function getCurrentUser(token: string) {
+  const session = await db.select().from(sessions).where(eq(sessions.token, token));
+  
+  if (session.length === 0) {
+    throw new Error('Unauthorized');
+  }
+  
+  const user = await db.select().from(users).where(eq(users.id, session[0].userId));
+  
+  if (user.length === 0) {
+    throw new Error('Unauthorized');
+  }
+  
+  return {
+    data: {
+      id: user[0].id,
+      name: user[0].name,
+      email: user[0].email,
+      created_at: user[0].createdAt,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add `getCurrentUser` function to users-service that validates token and returns user data
- Add `GET /api/users/me` endpoint with Bearer token authentication
- All test cases passed: valid token, invalid token, missing header

Closes #7